### PR TITLE
Enable checks on `publish_start`/`publish_end` by default

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -537,4 +537,8 @@ return [
 
         'default' => 'it',
     ],
+
+    'Publish' => [
+        'checkDate' => true,
+    ],
 ];


### PR DESCRIPTION
This MR changes the default app configuration to enable `Publish.checkDate`, which enables checks on `publish_start` and `publish_end` fields when filtering "published" objects.